### PR TITLE
fix lab manual target class from "Teacher" to "Student" in MOD04-EX4-T2c

### DIFF
--- a/Instructions/20483D_MOD04_LAB_MANUAL.md
+++ b/Instructions/20483D_MOD04_LAB_MANUAL.md
@@ -335,7 +335,7 @@ to create a new generic **List** collection.
     -   If the student is not part of the class, throw an **ArgumentException**
         exception to show that the student is not assigned to this class.
 
-3.  In the **Teacher** class, implement the **AddGrade** method as follows:
+3.  In the **Student** class, implement the **AddGrade** method as follows:
 
     -   Verify that the **Grade** object passed to the method does not belong to
         another student.


### PR DESCRIPTION
An issue exists for lab manual markdown file for MOD04-EX4-T2c task where a wrong target class type is stated, i.e. the student is instructed to implement a method for adding grades inside the Teacher class, but the actual implementation goes (and should go with this PR) into the Student.