### PR TITLE
Replace Buxton Sketch in instructions

### DIFF
--- a/Allfiles/Mod09/Labfiles/Solution/Exercise 2/Grades.WPF/Themes/Generic.xaml
+++ b/Allfiles/Mod09/Labfiles/Solution/Exercise 2/Grades.WPF/Themes/Generic.xaml
@@ -339,7 +339,7 @@
     <Style x:Key="LabelStyle" TargetType="{x:Type TextBlock}">
         <!-- TODO: Exercise 2: Task 2a: Define the label styling used throughout the application -->
         <Setter Property="TextWrapping" Value="NoWrap"/>
-        <Setter Property="FontFamily" Value="Segoe UI"/>
+        <Setter Property="FontFamily" Value="Comic Sans MS"/>
         <Setter Property="FontSize" Value="19"/>
         <Setter Property="Foreground" Value="#FF303030" />
     </Style>
@@ -360,7 +360,7 @@
     <Style x:Key="TextBoxStyle" TargetType="{x:Type TextBox}">
         <!-- TODO: Exercise 2: Task 2b: Define the text styling used throughout the application -->
         <Setter Property="TextWrapping" Value="NoWrap"/>
-        <Setter Property="FontFamily" Value="Segoe UI"/>
+        <Setter Property="FontFamily" Value="Comic Sans MS"/>
         <Setter Property="FontSize" Value="12"/>
         <Setter Property="TextAlignment" Value="Left" />
         <Setter Property="Foreground" Value="#FF303030" />

--- a/Allfiles/Mod09/Labfiles/Solution/Exercise 3/Grades.WPF/Themes/Generic.xaml
+++ b/Allfiles/Mod09/Labfiles/Solution/Exercise 3/Grades.WPF/Themes/Generic.xaml
@@ -339,7 +339,7 @@
     <Style x:Key="LabelStyle" TargetType="{x:Type TextBlock}">
         
         <Setter Property="TextWrapping" Value="NoWrap"/>
-        <Setter Property="FontFamily" Value="Segoe UI"/>
+        <Setter Property="FontFamily" Value="Comic Sans MS"/>
         <Setter Property="FontSize" Value="19"/>
         <Setter Property="Foreground" Value="#FF303030" />
     </Style>
@@ -360,7 +360,7 @@
     <Style x:Key="TextBoxStyle" TargetType="{x:Type TextBox}">
         
         <Setter Property="TextWrapping" Value="NoWrap"/>
-        <Setter Property="FontFamily" Value="Segoe UI"/>
+        <Setter Property="FontFamily" Value="Comic Sans MS"/>
         <Setter Property="FontSize" Value="12"/>
         <Setter Property="TextAlignment" Value="Left" />
         <Setter Property="Foreground" Value="#FF303030" />

--- a/Allfiles/Mod09/Labfiles/Starter/Exercise 3/Grades.WPF/Themes/Generic.xaml
+++ b/Allfiles/Mod09/Labfiles/Starter/Exercise 3/Grades.WPF/Themes/Generic.xaml
@@ -339,7 +339,7 @@
     <Style x:Key="LabelStyle" TargetType="{x:Type TextBlock}">
         
         <Setter Property="TextWrapping" Value="NoWrap"/>
-        <Setter Property="FontFamily" Value="Segoe UI"/>
+        <Setter Property="FontFamily" Value="Comic Sans MS"/>
         <Setter Property="FontSize" Value="19"/>
         <Setter Property="Foreground" Value="#FF303030" />
     </Style>
@@ -360,7 +360,7 @@
     <Style x:Key="TextBoxStyle" TargetType="{x:Type TextBox}">
         
         <Setter Property="TextWrapping" Value="NoWrap"/>
-        <Setter Property="FontFamily" Value="Segoe UI"/>
+        <Setter Property="FontFamily" Value="Comic Sans MS"/>
         <Setter Property="FontSize" Value="12"/>
         <Setter Property="TextAlignment" Value="Left" />
         <Setter Property="Foreground" Value="#FF303030" />

--- a/Instructions/20483C_MOD09_LAB_MANUAL.md
+++ b/Instructions/20483C_MOD09_LAB_MANUAL.md
@@ -233,13 +233,13 @@ Finally, you will run the application to verify that the styling of the text ele
 2. Locate the **\<!-- TODO: Exercise 2: Task 2a: Define the label styling used throughout the application --\>** comment near the end of the file.
 3. Below this comment, set the properties of the **LabelStyle** style by using the following information:
    - TextWrapping: **NoWrap**
-   - FontFamily: **Buxton Sketch**
+   - FontFamily: **Comic Sans MS**
    - FontSize: **19**
    - Foreground: **#FF303030**
 4. Locate the **\<!-- TODO: Exercise 2: Task 2b: Define the text styling used throughout the application --\>** comment.
 5. Below this comment, set the properties of the **TextBoxStyle** style by using the following information:
    - TextWrapping: **NoWrap**
-   - FontFamily: **Buxton Sketch**
+   - FontFamily: **Comic Sans MS**
    - FontSize: **12**
    - TextAlignment: **Left**
    - Foreground: **#FF303030**

--- a/Instructions/20483C_MOD09_LAK.md
+++ b/Instructions/20483C_MOD09_LAK.md
@@ -189,7 +189,7 @@ Estimated Time: **90 minutes**
 3. Click in the blank line below the comment, and type the following markup:
     ```xml
     <Setter Property="TextWrapping" Value="NoWrap"/>
-    <Setter Property="FontFamily" Value="Buxton Sketch"/>
+    <Setter Property="FontFamily" Value="Comic Sans MS"/>
     <Setter Property="FontSize" Value="19"/>
     <Setter Property="Foreground" Value="#FF303030" />
     ```
@@ -197,7 +197,7 @@ Estimated Time: **90 minutes**
 5. Click in the blank line below the comment, then type the following markup:
     ```xml
     <Setter Property="TextWrapping" Value="NoWrap"/>
-    <Setter Property="FontFamily" Value="Buxton Sketch"/>
+    <Setter Property="FontFamily" Value="Comic Sans MS"/>
     <Setter Property="FontSize" Value="12"/>
     <Setter Property="TextAlignment" Value="Left" />
     <Setter Property="Foreground" Value="#FF303030" />


### PR DESCRIPTION
Buxton Sketch is not available on all Windows installs. Comic Sans MS is installed with Windows 10 and has a similar appearance as Buxton Sketch. The previous update which replaces Buxton with Segoe only changed the solution files but not the instructions to students. Also changing to Segoe UI introduces such a small change to the fonts that most students wont immediately notice the difference to regular system fonts.